### PR TITLE
Implement undo, reset, and jump-to-move mechanics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,125 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback, useMemo, useReducer } from "react";
 
 import { ChessBoard } from "./components/ChessBoard";
 import { MoveList } from "./components/MoveList";
-import type { Move } from "./lib/types";
+import { createInitialBoardState, applyMove } from "./lib/chessEngine";
+import type { Move, BoardState } from "./lib/types";
+
+interface GameState {
+  moveHistory: readonly Move[];
+  currentMoveIndex: number;
+}
+
+type GameAction =
+  | { type: "MOVE"; move: Move }
+  | { type: "UNDO" }
+  | { type: "RESET" }
+  | { type: "JUMP_TO_MOVE"; targetIndex: number };
+
+function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "MOVE": {
+      const { move } = action;
+      if (state.currentMoveIndex < state.moveHistory.length - 1) {
+        // If we're not at the end, truncate history and add new move
+        const truncatedHistory = state.moveHistory.slice(0, state.currentMoveIndex + 1);
+        const newHistory = [...truncatedHistory, move];
+        return {
+          moveHistory: newHistory,
+          currentMoveIndex: newHistory.length - 1
+        };
+      } else {
+        // Normal case: append to end
+        const newHistory = [...state.moveHistory, move];
+        return {
+          moveHistory: newHistory,
+          currentMoveIndex: newHistory.length - 1
+        };
+      }
+    }
+    case "UNDO": {
+      if (state.currentMoveIndex >= 0) {
+        return {
+          ...state,
+          currentMoveIndex: state.currentMoveIndex - 1
+        };
+      }
+      return state;
+    }
+    case "RESET": {
+      return {
+        moveHistory: [],
+        currentMoveIndex: -1
+      };
+    }
+    case "JUMP_TO_MOVE": {
+      const { targetIndex } = action;
+      if (targetIndex >= -1 && targetIndex < state.moveHistory.length) {
+        return {
+          ...state,
+          currentMoveIndex: targetIndex
+        };
+      }
+      return state;
+    }
+    default:
+      return state;
+  }
+}
 
 export const App: React.FC = () => {
-  const [moveHistory, setMoveHistory] = useState<readonly Move[]>([]);
+  const [{ moveHistory, currentMoveIndex }, dispatch] = useReducer(gameReducer, {
+    moveHistory: [],
+    currentMoveIndex: -1
+  });
 
+  /**
+   * Computes the current board state based on move history and current position.
+   */
+  const currentBoardState = useMemo((): BoardState => {
+    let boardState = createInitialBoardState();
+    const movesToApply = moveHistory.slice(0, currentMoveIndex + 1);
+    for (const move of movesToApply) {
+      const movingPiece = boardState.squares.get(move.from);
+      if (!movingPiece) {
+        break;
+      }
+      const stateForMove: BoardState = { ...boardState, activeColor: movingPiece.color };
+      boardState = applyMove(stateForMove, move);
+    }
+    return boardState;
+  }, [moveHistory, currentMoveIndex]);
+
+  /**
+   * Handles a new move, implementing linear history (overwrites future moves if any).
+   */
   const handleMove = useCallback((move: Move) => {
-    setMoveHistory((prev) => [...prev, move]);
+    dispatch({ type: "MOVE", move });
   }, []);
+
+  /**
+   * Handles undo: steps back one move.
+   */
+  const handleUndo = useCallback(() => {
+    dispatch({ type: "UNDO" });
+  }, []);
+
+  /**
+   * Handles reset: returns to initial position and clears kifu.
+   */
+  const handleReset = useCallback(() => {
+    dispatch({ type: "RESET" });
+  }, []);
+
+  /**
+   * Handles jumping to a specific move index in the kifu.
+   */
+  const handleJumpToMove = useCallback((targetIndex: number) => {
+    dispatch({ type: "JUMP_TO_MOVE", targetIndex });
+  }, []);
+
+  const canUndo = currentMoveIndex >= 0;
+  const visibleMoves = moveHistory.slice(0, currentMoveIndex + 1);
 
   return (
     <main className="app-container">
@@ -21,10 +131,22 @@ export const App: React.FC = () => {
       </header>
       <div className="app-content">
         <section className="app-board-section">
-          <ChessBoard onMove={handleMove} />
+          <div className="app-board-controls">
+            <button type="button" onClick={handleUndo} disabled={!canUndo} aria-label="Undo move">
+              Undo
+            </button>
+            <button type="button" onClick={handleReset} aria-label="Reset game">
+              New Game
+            </button>
+          </div>
+          <ChessBoard boardState={currentBoardState} onMove={handleMove} />
         </section>
         <aside className="app-sidebar">
-          <MoveList moves={moveHistory} />
+          <MoveList
+            moves={visibleMoves}
+            currentMoveIndex={currentMoveIndex}
+            onMoveClick={handleJumpToMove}
+          />
         </aside>
       </div>
     </main>

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, it, test } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { App } from "../src/App";
 
@@ -11,5 +13,261 @@ describe("App", () => {
 
     // Check that chessboard is rendered
     expect(screen.getByRole("grid", { name: "Chess board" })).toBeInTheDocument();
+  });
+
+  describe("Undo functionality", () => {
+    it("should render undo button", () => {
+      render(<App />);
+      const undoButton = screen.getByRole("button", { name: /undo/i });
+      expect(undoButton).toBeInTheDocument();
+    });
+
+    it("should be disabled when there are no moves", () => {
+      render(<App />);
+      const undoButton = screen.getByRole("button", { name: /undo/i });
+      expect(undoButton).toBeDisabled();
+    });
+
+    it("should undo exactly one move and update board and kifu", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make a move: e2 -> e4
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+        expect(screen.getByText(/e4/)).toBeInTheDocument();
+      });
+
+      // Undo the move
+      const undoButton = screen.getByRole("button", { name: /undo/i });
+      await user.click(undoButton);
+
+      await waitFor(() => {
+        // Board should be back to initial state
+        expect(e2Square).toHaveTextContent("♙");
+        expect(e4Square).not.toHaveTextContent("♙");
+        // Kifu should not show e4
+        expect(screen.queryByText(/e4/)).not.toBeInTheDocument();
+      });
+    });
+
+    it("should undo multiple moves one at a time", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make two moves: e2->e4, e7->e5
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+      });
+
+      const e7Square = screen.getByLabelText(/square e7/i);
+      const e5Square = screen.getByLabelText(/square e5/i);
+      await user.click(e7Square);
+      await user.click(e5Square);
+
+      await waitFor(() => {
+        expect(e5Square).toHaveTextContent("♟");
+        expect(screen.getByText(/e5/)).toBeInTheDocument();
+      });
+
+      // Undo first move (e5)
+      const undoButton = screen.getByRole("button", { name: /undo/i });
+      await user.click(undoButton);
+
+      await waitFor(() => {
+        expect(e5Square).not.toHaveTextContent("♟");
+        expect(screen.queryByText(/e5/)).not.toBeInTheDocument();
+        // e4 should still be there
+        expect(e4Square).toHaveTextContent("♙");
+        expect(screen.getByText(/e4/)).toBeInTheDocument();
+      });
+
+      // Undo second move (e4)
+      await user.click(undoButton);
+
+      await waitFor(() => {
+        expect(e4Square).not.toHaveTextContent("♙");
+        expect(e2Square).toHaveTextContent("♙");
+        expect(screen.queryByText(/e4/)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Jump to move functionality", () => {
+    it("should allow clicking a move in kifu to jump to that position", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make three moves: e2->e4, e7->e5, g1->f3
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+      });
+
+      const e7Square = screen.getByLabelText(/square e7/i);
+      const e5Square = screen.getByLabelText(/square e5/i);
+      await user.click(e7Square);
+      await user.click(e5Square);
+
+      await waitFor(() => {
+        expect(e5Square).toHaveTextContent("♟");
+      });
+
+      const g1Square = screen.getByLabelText(/square g1/i);
+      const f3Square = screen.getByLabelText(/square f3/i);
+      await user.click(g1Square);
+      await user.click(f3Square);
+
+      await waitFor(() => {
+        expect(f3Square).toHaveTextContent("♞");
+      });
+
+      // Click on the first move (e4) in the kifu
+      const e4Move = screen.getByText(/e4/);
+      await user.click(e4Move);
+
+      await waitFor(() => {
+        // Board should show position after e4 (before e5)
+        expect(e4Square).toHaveTextContent("♙");
+        expect(e5Square).not.toHaveTextContent("♟");
+        expect(f3Square).not.toHaveTextContent("♞");
+      });
+    });
+
+    it("should update current move pointer when jumping to a move", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make two moves: e2->e4, e7->e5
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+      });
+
+      const e7Square = screen.getByLabelText(/square e7/i);
+      const e5Square = screen.getByLabelText(/square e5/i);
+      await user.click(e7Square);
+      await user.click(e5Square);
+
+      await waitFor(() => {
+        expect(e5Square).toHaveTextContent("♟");
+      });
+
+      // Jump to first move
+      const e4Move = screen.getByText(/e4/);
+      await user.click(e4Move);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+      });
+
+      // Make a new move after jumping back
+      const g1Square = screen.getByLabelText(/square g1/i);
+      const f3Square = screen.getByLabelText(/square f3/i);
+      await user.click(g1Square);
+      await user.click(f3Square);
+
+      await waitFor(() => {
+        // e5 should be gone (overwritten by linear history)
+        expect(screen.queryByText(/e5/)).not.toBeInTheDocument();
+        // f3 should be there
+        expect(f3Square).toHaveTextContent("♞");
+        expect(screen.getByText(/Nf3/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Reset/New Game functionality", () => {
+    it("should render reset button", () => {
+      render(<App />);
+      const resetButton = screen.getByRole("button", { name: /reset|new game/i });
+      expect(resetButton).toBeInTheDocument();
+    });
+
+    it("should reset to initial position and clear kifu", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make a move
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+        expect(screen.getByText(/e4/)).toBeInTheDocument();
+      });
+
+      // Reset
+      const resetButton = screen.getByRole("button", { name: /reset|new game/i });
+      await user.click(resetButton);
+
+      await waitFor(() => {
+        // Board should be back to initial state
+        expect(e2Square).toHaveTextContent("♙");
+        expect(e4Square).not.toHaveTextContent("♙");
+        // Kifu should be empty
+        expect(screen.queryByText(/e4/)).not.toBeInTheDocument();
+        const moveList = screen.getByRole("list", { name: /move list/i });
+        expect(moveList).toBeEmptyDOMElement();
+      });
+    });
+
+    it("should reset from arbitrary state", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Make multiple moves
+      const e2Square = screen.getByLabelText(/square e2/i);
+      const e4Square = screen.getByLabelText(/square e4/i);
+      await user.click(e2Square);
+      await user.click(e4Square);
+
+      await waitFor(() => {
+        expect(e4Square).toHaveTextContent("♙");
+      });
+
+      const e7Square = screen.getByLabelText(/square e7/i);
+      const e5Square = screen.getByLabelText(/square e5/i);
+      await user.click(e7Square);
+      await user.click(e5Square);
+
+      await waitFor(() => {
+        expect(e5Square).toHaveTextContent("♟");
+      });
+
+      // Reset
+      const resetButton = screen.getByRole("button", { name: /reset|new game/i });
+      await user.click(resetButton);
+
+      await waitFor(() => {
+        // All pieces should be in initial positions
+        expect(e2Square).toHaveTextContent("♙");
+        expect(e4Square).not.toHaveTextContent("♙");
+        expect(e5Square).not.toHaveTextContent("♟");
+        // Kifu should be empty
+        const moveList = screen.getByRole("list", { name: /move list/i });
+        expect(moveList).toBeEmptyDOMElement();
+      });
+    });
   });
 });

--- a/tests/components/MoveList.test.tsx
+++ b/tests/components/MoveList.test.tsx
@@ -24,7 +24,7 @@ const mockDownloadTextFile = vi.mocked(downloadTextFile);
 describe("MoveList", () => {
   describe("Rendering", () => {
     it("should render empty list when no moves provided", () => {
-      render(<MoveList moves={[]} />);
+      render(<MoveList moves={[]} currentMoveIndex={-1} />);
       const moveList = screen.getByRole("list", { name: /move list/i });
       expect(moveList).toBeInTheDocument();
       expect(moveList).toBeEmptyDOMElement();
@@ -36,7 +36,7 @@ describe("MoveList", () => {
         { from: "e7", to: "e5" },
         { from: "g1", to: "f3" }
       ];
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={2} />);
 
       expect(screen.getByText(/1\./)).toBeInTheDocument();
       expect(screen.getByText(/e4/)).toBeInTheDocument();
@@ -51,7 +51,7 @@ describe("MoveList", () => {
         { from: "g1", to: "f3" },
         { from: "b8", to: "c6" }
       ];
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={3} />);
 
       // First move pair (1. e4 e5)
       expect(screen.getByText(/1\./)).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe("MoveList", () => {
 
     it("should handle odd number of moves (white move without black response)", () => {
       const moves: Move[] = [{ from: "e2", to: "e4" }];
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={0} />);
 
       expect(screen.getByText(/1\./)).toBeInTheDocument();
       expect(screen.getByText(/e4/)).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("MoveList", () => {
 
   describe("Accessibility", () => {
     it("should have proper ARIA label", () => {
-      render(<MoveList moves={[]} />);
+      render(<MoveList moves={[]} currentMoveIndex={-1} />);
       const moveList = screen.getByRole("list", { name: /move list/i });
       expect(moveList).toBeInTheDocument();
     });
@@ -84,7 +84,7 @@ describe("MoveList", () => {
     });
 
     it("should render copy button", () => {
-      render(<MoveList moves={[]} />);
+      render(<MoveList moves={[]} currentMoveIndex={-1} />);
       const copyButton = screen.getByRole("button", { name: /copy moves/i });
       expect(copyButton).toBeInTheDocument();
     });
@@ -98,7 +98,7 @@ describe("MoveList", () => {
         { from: "e7", to: "e5" }
       ];
 
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={1} />);
 
       const copyButton = screen.getByRole("button", { name: /copy moves/i });
       await user.click(copyButton);
@@ -118,7 +118,7 @@ describe("MoveList", () => {
       mockCopyTextToClipboard.mockRejectedValue(new Error("Clipboard access denied"));
 
       const moves: Move[] = [{ from: "e2", to: "e4" }];
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={0} />);
 
       const copyButton = screen.getByRole("button", { name: /copy moves/i });
       await user.click(copyButton);
@@ -134,7 +134,7 @@ describe("MoveList", () => {
       const user = userEvent.setup();
       mockCopyTextToClipboard.mockClear();
 
-      render(<MoveList moves={[]} />);
+      render(<MoveList moves={[]} currentMoveIndex={-1} />);
 
       const copyButton = screen.getByRole("button", { name: /copy moves/i });
       await user.click(copyButton);
@@ -152,7 +152,7 @@ describe("MoveList", () => {
     });
 
     it("should render download button", () => {
-      render(<MoveList moves={[]} />);
+      render(<MoveList moves={[]} currentMoveIndex={-1} />);
       const downloadButton = screen.getByRole("button", { name: /download moves/i });
       expect(downloadButton).toBeInTheDocument();
     });
@@ -166,7 +166,7 @@ describe("MoveList", () => {
         { from: "e7", to: "e5" }
       ];
 
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={1} />);
 
       const downloadButton = screen.getByRole("button", { name: /download moves/i });
       await user.click(downloadButton);
@@ -192,7 +192,7 @@ describe("MoveList", () => {
         { from: "e7", to: "e5" }
       ];
 
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={1} />);
 
       // For now, test that download button works (PGN option may be future enhancement)
       const downloadButton = screen.getByRole("button", { name: /download moves/i });
@@ -206,7 +206,7 @@ describe("MoveList", () => {
       mockDownloadTextFile.mockClear();
 
       const moves: Move[] = [{ from: "e2", to: "e4" }];
-      render(<MoveList moves={moves} />);
+      render(<MoveList moves={moves} currentMoveIndex={0} />);
 
       const downloadButton = screen.getByRole("button", { name: /download moves/i });
       await user.click(downloadButton);


### PR DESCRIPTION
Closes #7

## TDD & Lint Verification

- [x] I have written failing tests (Red) and confirmed `make test` fails for the new tests.
- [x] I have implemented code to pass tests (Green) and confirmed `make test` passes.
- [x] I have run `make lint` and fixed all errors.

## Self-Walkthrough (Logical Reasoning)

### Requirement R1: Undo button steps back exactly one move
**Implementation:** Added `handleUndo` callback that dispatches `UNDO` action to gameReducer. The reducer decrements `currentMoveIndex` by 1, which causes `currentBoardState` to recompute using `moveHistory.slice(0, currentMoveIndex + 1)`. This ensures the board shows the position after the previous move.

**Key Files:** `src/App.tsx` (gameReducer UNDO case, handleUndo callback), `src/components/ChessBoard.tsx` (receives updated boardState prop)

### Requirement R2: Clicking a move in kifu jumps to that position
**Implementation:** Modified `MoveList` to accept `currentMoveIndex` and `onMoveClick` props. Each move span is clickable and calls `onMoveClick` with the move index. `handleJumpToMove` dispatches `JUMP_TO_MOVE` action which sets `currentMoveIndex` to the target index. The board state recomputes to show the position after that move.

**Key Files:** `src/components/MoveList.tsx` (clickable moves with move indices), `src/App.tsx` (handleJumpToMove, JUMP_TO_MOVE reducer case)

### Requirement R3: Reset/New Game returns to initial position
**Implementation:** Added `handleReset` callback that dispatches `RESET` action. The reducer sets `moveHistory` to empty array and `currentMoveIndex` to -1, which causes `currentBoardState` to return the initial board state.

**Key Files:** `src/App.tsx` (gameReducer RESET case, handleReset callback)

### Requirement R4: Linear history after undo (new moves overwrite future moves)
**Implementation:** Modified `MOVE` action in gameReducer to check if `currentMoveIndex < moveHistory.length - 1`. If true, it truncates history to `moveHistory.slice(0, currentMoveIndex + 1)` before appending the new move. This ensures that any moves after the current position are discarded when a new move is made.

**Key Files:** `src/App.tsx` (gameReducer MOVE case with truncation logic)

### Requirement R5: Unit tests cover all scenarios
**Implementation:** Added comprehensive tests in `tests/App.test.tsx` covering:
- Undo from multiple positions (single and multiple moves)
- Jumping to arbitrary move indices
- Reset behavior from arbitrary states
- Linear history behavior (jumping back and making new moves)

**Key Files:** `tests/App.test.tsx` (all new test cases)

## Decision Log

- **State Management:** Chose `useReducer` over multiple `useState` hooks to ensure atomic state updates and avoid race conditions when updating both `moveHistory` and `currentMoveIndex` simultaneously.

- **Board State Computation:** Used `useMemo` to compute `currentBoardState` from `moveHistory` and `currentMoveIndex` to avoid recalculating on every render. The computation applies moves sequentially using `applyMove` from the chess engine.

- **MoveList Index Mapping:** Since `visibleMoves` is always a slice from the beginning of `moveHistory`, the indices in the `moves` array match the indices in `moveHistory`, allowing direct use of array indices for jump-to-move functionality.

- **Error Handling:** Modified `MoveList` to use `applyMoveInternal` (non-validating version) for SAN generation to avoid validation errors when reconstructing board state for display purposes, as the moves are already validated when made.