### PR TITLE
Fix pawn double-step path clearance validation

### DIFF
--- a/src/lib/chessEngine.ts
+++ b/src/lib/chessEngine.ts
@@ -162,6 +162,13 @@ function validatePawnMove(
 
     // Double square forward from starting position
     if (fromRank === startRank && rankDelta === 2 * direction) {
+      // Check that intermediate square is clear
+      const intermediateRank = fromRank + direction;
+      const intermediateSquare = move.from[0] + intermediateRank.toString();
+      const intermediatePiece = boardState.squares.get(intermediateSquare);
+      if (intermediatePiece) {
+        return { valid: false, reason: "Path is blocked" };
+      }
       return { valid: true };
     }
 

--- a/tests/lib/chessEngine.test.ts
+++ b/tests/lib/chessEngine.test.ts
@@ -1102,4 +1102,164 @@ describe("Chess Engine", () => {
       });
     });
   });
+
+  describe("Pawn double-step path clearance", () => {
+    let initialBoardState: BoardState;
+
+    beforeEach(() => {
+      initialBoardState = createInitialBoardState();
+    });
+
+    describe("White pawn double-step", () => {
+      it("should validate white pawn double-step when path is clear", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e2", { color: "white", type: "pawn" }],
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "white"
+        };
+        const move: Move = { from: "e2", to: "e4" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should reject white pawn double-step when intermediate square is occupied", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e2", { color: "white", type: "pawn" }],
+            ["e3", { color: "black", type: "pawn" }], // Blocking intermediate square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "white"
+        };
+        const move: Move = { from: "e2", to: "e4" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.reason).toBeDefined();
+        }
+      });
+
+      it("should reject white pawn double-step when destination square is occupied", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e2", { color: "white", type: "pawn" }],
+            ["e4", { color: "black", type: "pawn" }], // Blocking destination square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "white"
+        };
+        const move: Move = { from: "e2", to: "e4" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.reason).toBeDefined();
+        }
+      });
+    });
+
+    describe("Black pawn double-step", () => {
+      it("should validate black pawn double-step when path is clear", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e7", { color: "black", type: "pawn" }],
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "black"
+        };
+        const move: Move = { from: "e7", to: "e5" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should reject black pawn double-step when intermediate square is occupied", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e7", { color: "black", type: "pawn" }],
+            ["e6", { color: "white", type: "pawn" }], // Blocking intermediate square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "black"
+        };
+        const move: Move = { from: "e7", to: "e5" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.reason).toBeDefined();
+        }
+      });
+
+      it("should reject black pawn double-step when destination square is occupied", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e7", { color: "black", type: "pawn" }],
+            ["e5", { color: "white", type: "pawn" }], // Blocking destination square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "black"
+        };
+        const move: Move = { from: "e7", to: "e5" };
+        const result = validateMove(boardState, move);
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.reason).toBeDefined();
+        }
+      });
+    });
+
+    describe("getLegalMoves respects path clearance", () => {
+      it("should not include double-step in legal moves when intermediate square is blocked", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e2", { color: "white", type: "pawn" }],
+            ["e3", { color: "black", type: "pawn" }], // Blocking intermediate square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "white"
+        };
+        const legalMoves = getLegalMoves(boardState, "e2");
+
+        expect(legalMoves).not.toContain("e4"); // Double-step should not be legal
+        expect(legalMoves).not.toContain("e3"); // Single-step should also be blocked (forward moves require empty square)
+        // Diagonal capture moves may still be legal
+      });
+
+      it("should not include double-step in legal moves when destination square is blocked", () => {
+        const boardState: BoardState = {
+          ...initialBoardState,
+          squares: new Map([
+            ["e2", { color: "white", type: "pawn" }],
+            ["e4", { color: "black", type: "pawn" }], // Blocking destination square
+            ["e1", { color: "white", type: "king" }],
+            ["e8", { color: "black", type: "king" }]
+          ]),
+          activeColor: "white"
+        };
+        const legalMoves = getLegalMoves(boardState, "e2");
+
+        expect(legalMoves).not.toContain("e4"); // Double-step should not be legal
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Overview

Closes #32

## TDD & Lint Verification

- [x] I have written failing tests (Red) and confirmed `make test` fails for the new tests.
- [x] I have implemented code to pass tests (Green) and confirmed `make test` passes.
- [x] I have run `make lint` and fixed all errors.

## Self-Walkthrough (Logical Reasoning)

| Requirement (ID)     | Implementation & Logic                                          | Key File/Function |
| :------------------- | :-------------------------------------------------------------- | :---------------- |
| R1: Validate intermediate square for double-step | Added check in `validatePawnMove` to verify intermediate square is empty before allowing double-step move. Calculated intermediate square as `fromRank + direction` and checked if occupied. | `src/lib/chessEngine.ts:validatePawnMove` |
| R2: Reject blocked double-step moves | Return `{ valid: false, reason: "Path is blocked" }` when intermediate square contains any piece. This prevents pawns from jumping over pieces, which violates chess rules. | `src/lib/chessEngine.ts:validatePawnMove` |
| R3: Ensure getLegalMoves respects validation | Since `getLegalMoves` calls `validateMove` for each potential destination, the path clearance check automatically filters out illegal double-step moves. Added tests to verify this behavior. | `tests/lib/chessEngine.test.ts` |
| R4: Test coverage for both colors | Added comprehensive test cases for white and black pawns, covering positive case (clear path) and negative cases (intermediate blocked, destination blocked). | `tests/lib/chessEngine.test.ts:Pawn double-step path clearance` |

**Implementation Details:**
- The fix calculates the intermediate square by adding the pawn's direction (1 for white, -1 for black) to the starting rank.
- The intermediate square is constructed using the same file letter as the move origin and the calculated intermediate rank.
- If any piece occupies the intermediate square, the move is rejected with a descriptive error message.
- This ensures that `getLegalMoves` and `applyMove` correctly reflect the validation, as they both rely on `validateMove`.

## Decision Log

- **Chose explicit intermediate square calculation** over reusing `isPathClear` function because pawn double-step is a special case with only one intermediate square, making explicit calculation clearer and more efficient.
- **Used consistent error message "Path is blocked"** to match the pattern used by other piece validators (rook, bishop, queen) for consistency.
- **Added tests for both colors** to ensure the fix works correctly regardless of pawn color, as the direction calculation differs between white and black pawns.